### PR TITLE
Update quickStart.rst

### DIFF
--- a/docs/gettingStarted/quickStart.rst
+++ b/docs/gettingStarted/quickStart.rst
@@ -70,7 +70,7 @@ Running CWL workflows using Toil is easy.
 #. First ensure that Toil is installed with the
    ``cwl`` extra (see :ref:`extras`).  ::
 
-       (venv) $ pip install toil[cwl]
+       (venv) $ pip install 'toil[cwl]'
 
    This installs the ``toil-cwl-runner`` and ``cwl-runner`` executables. These are identical -
    ``cwl-runner`` is the portable name for the default system CWL runner.


### PR DESCRIPTION
pip is picky about installing libraries with extra requirements. 

pip 9.0.1 works with quotes

https://stackoverflow.com/questions/19096155/setuptools-and-pip-choice-of-minimal-and-complete-install