### PR TITLE
Update lsf.py

### DIFF
--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -117,7 +117,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
                     logger.error("bjobs detected job failed for job: "
                                  "{}".format(job))
                     return 1
-                elif line.find("Started on ") > -1:
+                elif line.find("Started on ") > -1 or re.search('Started \d* Task', line):
                     started = 1
 
             if started == 1:


### PR DESCRIPTION
Our lsf configuration prints the following status for running jobs:

```
Tue Sep 24 19:12:37: Started 1 Task(s) on Host(s) <jx15>, Allocated 1 Slot(s) 
```

This isn't matched by `Started on`, so we'd like to make this more flexible if possible